### PR TITLE
🐛 fix: image error loop and broken test

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -113,8 +113,9 @@ function handleImageErrors() {
       const img = target as HTMLImageElement;
       // Prevent infinite loops if the placeholder itself fails to load
       const placeholder = '/lion.png';
-      if (!img.src.includes('/lion.png')) {
-        img.src = placeholder;
+      const placeholderUrl = new URL(placeholder, window.location.href).href;
+      if (img.src !== placeholderUrl) {
+        img.src = placeholderUrl;
       }
     }
   }, true); // useCapture must be true for error events

--- a/src/modules/__tests__/dataService.bench.test.ts
+++ b/src/modules/__tests__/dataService.bench.test.ts
@@ -36,7 +36,9 @@ vi.mock('../supabase', () => {
 
   return {
     get supabase() { return mockClient },
-    get supabaseAdmin() { return null }
+    get supabaseAdmin() { return null },
+    isSupabaseStorageUrl: vi.fn().mockReturnValue(false),
+    cacheImageFromUrl: vi.fn().mockImplementation(async (url) => url)
   }
 })
 


### PR DESCRIPTION
Fixed image error loading loop in src/main.ts and fixed dataService bench test

---
*PR created automatically by Jules for task [4552469739683222374](https://jules.google.com/task/4552469739683222374) started by @atakhadiviom*