### PR TITLE
🧪 Add tests for labelFromUrl in details.ts

### DIFF
--- a/src/modules/__tests__/details.test.ts
+++ b/src/modules/__tests__/details.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { labelFromUrl } from '../details'
+
+describe('labelFromUrl', () => {
+  it('returns appropriate labels for known domains', () => {
+    expect(labelFromUrl('https://t.me/something')).toBe('Telegram')
+    expect(labelFromUrl('https://www.instagram.com/p/123')).toBe('Instagram')
+    expect(labelFromUrl('https://x.com/abc')).toBe('X (Twitter)')
+    expect(labelFromUrl('https://twitter.com/abc')).toBe('X (Twitter)')
+    expect(labelFromUrl('https://www.youtube.com/watch?v=123')).toBe('YouTube')
+    expect(labelFromUrl('https://youtu.be/123')).toBe('YouTube')
+    expect(labelFromUrl('https://facebook.com/something')).toBe('Facebook')
+    expect(labelFromUrl('https://fb.com/something')).toBe('Facebook')
+    expect(labelFromUrl('https://hengaw.net/en')).toBe('Hengaw')
+    expect(labelFromUrl('https://iranhr.net/en')).toBe('IranHR')
+    expect(labelFromUrl('https://amnesty.org/en')).toBe('Amnesty International')
+    expect(labelFromUrl('https://iranwire.com/en')).toBe('IranWire')
+    expect(labelFromUrl('https://iranvictims.com/en')).toBe('Iran Victims')
+  })
+
+  it('capitalizes the first part of the domain for unknown domains', () => {
+    expect(labelFromUrl('https://example.com/path')).toBe('Example')
+    expect(labelFromUrl('https://www.bbc.com/news')).toBe('Bbc')
+    expect(labelFromUrl('http://my-site.org')).toBe('My-site')
+  })
+
+  it('returns "Source" for invalid URLs that throw in new URL()', () => {
+    expect(labelFromUrl('invalid-url')).toBe('Source')
+    expect(labelFromUrl('')).toBe('Source')
+    expect(labelFromUrl('not a url')).toBe('Source')
+  })
+})


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `labelFromUrl` function in `src/modules/details.ts`, specifically missing coverage for the `catch` block error path when an invalid URL is provided.

📊 **Coverage:** The new test suite comprehensively covers scenarios for:
- Known domains (e.g., Telegram, X, Instagram, etc.) mapping to appropriate labels.
- Unknown domains falling back to capitalized domain names.
- Invalid URLs correctly triggering the `catch` block and returning `'Source'`.

✨ **Result:** Test coverage for `src/modules/details.ts` is improved, ensuring regressions on domain labeling and error paths are caught in the future.

---
*PR created automatically by Jules for task [9522631414327171026](https://jules.google.com/task/9522631414327171026) started by @atakhadiviom*