### PR TITLE
🧪 Add tests for cacheImageFromUrl

### DIFF
--- a/src/modules/__tests__/dataService.bench.test.ts
+++ b/src/modules/__tests__/dataService.bench.test.ts
@@ -36,7 +36,9 @@ vi.mock('../supabase', () => {
 
   return {
     get supabase() { return mockClient },
-    get supabaseAdmin() { return null }
+    get supabaseAdmin() { return null },
+    cacheImageFromUrl: vi.fn().mockResolvedValue('http://example.supabase.co/photo.jpg'),
+    isSupabaseStorageUrl: vi.fn().mockReturnValue(false)
   }
 })
 

--- a/src/modules/__tests__/supabase.test.ts
+++ b/src/modules/__tests__/supabase.test.ts
@@ -172,3 +172,100 @@ describe('uploadImageToSupabase', () => {
     )
   })
 })
+
+describe('cacheImageFromUrl', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    originalEnv = { ...process.env }
+
+    process.env.VITE_SUPABASE_URL = 'https://example.supabase.co'
+    process.env.VITE_SUPABASE_ANON_KEY = 'mock-anon-key'
+    process.env.VITE_SUPABASE_SERVICE_ROLE_KEY = 'mock-service-role-key'
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.unstubAllGlobals()
+  })
+
+  it('returns null if url is falsy', async () => {
+    const { cacheImageFromUrl } = await import('../supabase')
+    const result = await cacheImageFromUrl('')
+    expect(result).toBeNull()
+  })
+
+  it('returns the URL immediately if it is already a Supabase storage URL', async () => {
+    const { cacheImageFromUrl } = await import('../supabase')
+    const url = 'https://example.supabase.co/storage/v1/object/public/memorial-images/mock.jpg'
+    const result = await cacheImageFromUrl(url)
+    expect(result).toBe(url)
+  })
+
+  it('returns null and logs error if the fetch response is not ok', async () => {
+    const { cacheImageFromUrl } = await import('../supabase')
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found'
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const result = await cacheImageFromUrl('http://example.com/test.jpg')
+
+    expect(result).toBeNull()
+    expect(fetchMock).toHaveBeenCalledWith('http://example.com/test.jpg', undefined)
+    expect(consoleSpy).toHaveBeenCalledWith('Image download failed:', 404, 'Not Found', 'http://example.com/test.jpg')
+    consoleSpy.mockRestore()
+  })
+
+  it('returns null and logs exception if fetch throws an error', async () => {
+    const { cacheImageFromUrl } = await import('../supabase')
+    const mockError = new Error('Network error')
+    const fetchMock = vi.fn().mockRejectedValue(mockError)
+    vi.stubGlobal('fetch', fetchMock)
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const result = await cacheImageFromUrl('http://example.com/test.jpg')
+
+    expect(result).toBeNull()
+    expect(fetchMock).toHaveBeenCalledWith('http://example.com/test.jpg', undefined)
+    expect(consoleSpy).toHaveBeenCalledWith('Image cache exception:', mockError)
+    consoleSpy.mockRestore()
+  })
+
+  it('calls uploadImageToSupabase and returns resulting URL on success', async () => {
+    const { cacheImageFromUrl } = await import('../supabase')
+    const arrayBuffer = new ArrayBuffer(8)
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(arrayBuffer)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    mockUpload.mockResolvedValueOnce({ error: null })
+    mockGetPublicUrl.mockReturnValueOnce({ data: { publicUrl: 'https://example.supabase.co/storage/v1/object/public/memorial-images/mock-uuid.jpg' } })
+
+    const mockUUID = '123e4567-e89b-12d3-a456-426614174000'
+    vi.stubGlobal('crypto', {
+      randomUUID: () => mockUUID
+    })
+
+    const result = await cacheImageFromUrl('http://example.com/test.jpg')
+
+    expect(result).toBe('https://example.supabase.co/storage/v1/object/public/memorial-images/mock-uuid.jpg')
+    expect(fetchMock).toHaveBeenCalledWith('http://example.com/test.jpg', undefined)
+    expect(mockUpload).toHaveBeenCalledWith(
+      `${mockUUID}.jpg`,
+      expect.any(ArrayBuffer),
+      {
+        contentType: 'image/jpeg',
+        upsert: false
+      }
+    )
+    expect(mockGetPublicUrl).toHaveBeenCalledWith(`${mockUUID}.jpg`)
+  })
+})


### PR DESCRIPTION
🎯 **What:** The testing gap for `cacheImageFromUrl` in `src/modules/supabase.ts` has been addressed. The test suite for `supabase.ts` was missing dedicated unit tests for this function.

📊 **Coverage:** The new test cases cover:
- Falsy/empty URLs returning `null`.
- URLs that are already Supabase storage URLs returning the URL immediately without fetching.
- Failed fetches (e.g., non-200 responses) returning `null` and logging an error.
- Thrown exceptions during the fetch or process returning `null` and logging an exception.
- Successful downloads converting the response to an ArrayBuffer, calling `uploadImageToSupabase`, and returning the uploaded URL.

✨ **Result:** Test coverage for `src/modules/supabase.ts` has been significantly improved, ensuring the robustness of the image caching behavior.

---
*PR created automatically by Jules for task [16427972573480303547](https://jules.google.com/task/16427972573480303547) started by @atakhadiviom*