### PR TITLE
🔒 Fix XSS vulnerability in reference links

### DIFF
--- a/src/modules/__tests__/domUtils.test.ts
+++ b/src/modules/__tests__/domUtils.test.ts
@@ -1,5 +1,34 @@
 import { describe, it, expect } from 'vitest'
-import { escapeHTML } from '../domUtils'
+import { escapeHTML, sanitizeUrl } from '../domUtils'
+
+describe('sanitizeUrl', () => {
+  it('returns about:blank for dangerous protocols', () => {
+    expect(sanitizeUrl('javascript:alert(1)')).toBe('about:blank')
+    expect(sanitizeUrl(' javascript:alert(1)')).toBe('about:blank')
+    expect(sanitizeUrl('\njavascript:alert(1)')).toBe('about:blank')
+    expect(sanitizeUrl('\rjavascript:alert(1)')).toBe('about:blank')
+    expect(sanitizeUrl('\tjavascript:alert(1)')).toBe('about:blank')
+    expect(sanitizeUrl('vbscript:alert(1)')).toBe('about:blank')
+    expect(sanitizeUrl('data:text/html,<script>alert(1)</script>')).toBe('about:blank')
+  })
+
+  it('allows http and https URLs', () => {
+    expect(sanitizeUrl('https://example.com')).toBe('https://example.com')
+    expect(sanitizeUrl('http://example.com')).toBe('http://example.com')
+  })
+
+  it('allows relative and absolute paths', () => {
+    expect(sanitizeUrl('/relative/path')).toBe('/relative/path')
+    expect(sanitizeUrl('relative/path')).toBe('relative/path')
+    expect(sanitizeUrl('#anchor')).toBe('#anchor')
+  })
+
+  it('handles empty strings and null/undefined', () => {
+    expect(sanitizeUrl('')).toBe('')
+    expect(sanitizeUrl(null)).toBe('')
+    expect(sanitizeUrl(undefined)).toBe('')
+  })
+})
 
 describe('escapeHTML', () => {
   it('escapes special characters', () => {

--- a/src/modules/details.ts
+++ b/src/modules/details.ts
@@ -1,6 +1,6 @@
 import { t, currentLanguage } from './i18n'
 import type { MemorialEntry } from './types'
-import { escapeHTML } from './domUtils'
+import { escapeHTML, sanitizeUrl } from './domUtils'
 import { logger } from './logger'
 import { renderPhotoFigure, wrapSensitive } from './detailsMedia'
 import { downloadMemorialPdf } from './pdf'
@@ -140,7 +140,8 @@ function buildMediaAndReferencesHTML(entry: MemorialEntry, isFa: boolean): strin
         <ul>
           ${entry.references.map(ref => {
             const label = (!ref.label || ref.label === 'Source') ? labelFromUrl(ref.url) : ref.label
-            return `<li><a href="${escapeHTML(ref.url)}" target="_blank" rel="noopener noreferrer">${escapeHTML(label)}</a></li>`
+            const safeUrl = sanitizeUrl(ref.url)
+            return `<li><a href="${escapeHTML(safeUrl)}" target="_blank" rel="noopener noreferrer">${escapeHTML(label)}</a></li>`
           }).join('')}
         </ul>
       </section>

--- a/src/modules/domUtils.ts
+++ b/src/modules/domUtils.ts
@@ -4,6 +4,27 @@
  * @param str The string to escape.
  * @returns The escaped string.
  */
+/**
+ * Sanitizes URLs to prevent javascript:, vbscript:, and data: execution.
+ *
+ * @param url The URL string to sanitize.
+ * @returns The sanitized URL or 'about:blank' if unsafe.
+ */
+export function sanitizeUrl(url: string | null | undefined): string {
+  if (!url) return '';
+  const trimmed = String(url).trim();
+  try {
+    const parsed = new URL(trimmed, 'http://dummy.com');
+    const protocol = parsed.protocol.toLowerCase();
+    if (['javascript:', 'vbscript:', 'data:'].includes(protocol)) {
+      return 'about:blank';
+    }
+    return trimmed;
+  } catch (e) {
+    return 'about:blank';
+  }
+}
+
 export function escapeHTML(str: string | null | undefined): string {
   if (str === null || str === undefined) return '';
   const s = String(str);


### PR DESCRIPTION
🎯 What:
Fixed a Cross-Site Scripting (XSS) vulnerability in the rendering of profile reference links in `src/modules/details.ts`.

⚠️ Risk:
The `href` attribute of reference links previously only escaped HTML characters. This allowed arbitrary javascript execution if an entry contained a reference with a `javascript:` or `vbscript:` URL protocol.

🛡️ Solution:
Added a robust `sanitizeUrl` utility function in `src/modules/domUtils.ts` that safely parses URLs using the WHATWG `URL` constructor to check protocols. It replaces dangerous protocols (`javascript:`, `vbscript:`, `data:`) with `about:blank` while preserving valid `http(s)` URLs and relative paths. Applied this sanitizer to the `ref.url` before HTML escaping. Included comprehensive test coverage in `src/modules/__tests__/domUtils.test.ts` to prevent regressions.

---
*PR created automatically by Jules for task [13222343767773039622](https://jules.google.com/task/13222343767773039622) started by @atakhadiviom*